### PR TITLE
aads compiler warning fix

### DIFF
--- a/aads/tree_traverse/bad.cpp
+++ b/aads/tree_traverse/bad.cpp
@@ -29,7 +29,7 @@ public:
         std::stringstream ss;
         ss << '[';
         print_node(ss, top);
-        std::string s(std::move(ss.str()));
+        std::string s(ss.str());
         s[s.size() - 1] = ']';
         return s;
     }


### PR DESCRIPTION
moving temporary object prevents copy elision

gcc wasn't reporting this on Ubuntu
only clang 14.0.0 on mac